### PR TITLE
Fixed path separator in get_output_paths (Windows)

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -104,4 +104,5 @@ module.exports = (opts) ->
     get_output_paths = (files, prefix) ->
       @util.files(files).map (f) =>
         filePath = @util.output_path(f.relative).relative
-        path.join(prefix, filePath.replace(path.extname(filePath), '.js'))
+        fN = path.join(prefix, filePath.replace(path.extname(filePath), '.js'))
+        fN.replace(new RegExp('\\' + path.sep, 'g'), '/')


### PR DESCRIPTION
Same change as a few weeks ago in roots-css-pipeline.