### PR TITLE
fix exception during UglifyJS.minify()

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -84,7 +84,7 @@ module.exports = (opts) ->
         all_contents = ''
         for matcher in @files
           for file, content of @file_map when minimatch(file, matcher)
-            all_contents += content
+            all_contents += content + "\n"
 
         if opts.minify
           all_contents = UglifyJS.minify(all_contents, opts.opts).code


### PR DESCRIPTION
Was getting an error during `roots compile -e production`:

    $ roots compile -e production
    compiling... [Error: Uncaught, unspecified "error" event.]

Traced it down to the minification step, where we pass in syntactically bad javascript. Just need a newline between each javascript file in the pipeline. More details in 2a36494.
